### PR TITLE
fix the inconsistent parameter of the compute_posterior in the line #446.

### DIFF
--- a/resolve.py
+++ b/resolve.py
@@ -444,10 +444,11 @@ if __name__ == '__main__':
         print('Step %d/%d' % (idx+1, num_steps))
         optimizer.zero_grad()
         loss = compute_posterior(est_hr_image, x_i, x_j,
-                                 Y_K, beta, center,
+                                 Y_K, center,
                                  estimated_shifts,
                                  estimated_angles,
                                  estimated_gamma,
+								 beta, 
                                  device)
         loss.backward()
         optimizer.step()


### PR DESCRIPTION
Hello, 

I found and corrected an inconsistent parameter usage of `compute_posterior` which causes `RuntimeError`. 

Thank You.